### PR TITLE
lets the app disply nothing when entering the diceActivity

### DIFF
--- a/DiceRoller/app/src/main/res/layout/activity_dice.xml
+++ b/DiceRoller/app/src/main/res/layout/activity_dice.xml
@@ -12,7 +12,8 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_horizontal"
-        android:src="@drawable/dice_1"/>
+        android:src="@drawable/empty_dice"
+        tools:src="@drawable/dice_1"/>
 
 
 


### PR DESCRIPTION
To still show an image when clicking on design in android studio a dummy picture is added with tools:source in addition to adroid:source